### PR TITLE
Minor doc improvement

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,8 +6,8 @@ Think async version of the [`do…while` statement](https://developer.mozilla.or
 
 ## Install
 
-```
-$ npm install p-do-whilst
+```sh
+npm install p-do-whilst
 ```
 
 ## Usage


### PR DESCRIPTION
Using a `sh` code block and removing the `$` makes it easier to copy-paste the install command and, in some cases when more complex commands are rendered, also brings in syntax highlight.